### PR TITLE
feat: add healthcheck lookup before redirect

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,4 +23,4 @@ jobs:
       run: go build -v .
 
     - name: Test
-      run: go test -v .
+      run: go test -v ./...

--- a/go.mod
+++ b/go.mod
@@ -7,19 +7,20 @@ require (
 	github.com/containerd/containerd v1.5.5 // indirect
 	github.com/docker/docker v20.10.8+incompatible
 	github.com/docker/go-connections v0.4.0 // indirect
-	github.com/gorilla/mux v1.7.3 // indirect
+	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/sirupsen/logrus v1.8.1
-	github.com/stretchr/testify v1.7.0 // indirect
+	github.com/stretchr/testify v1.7.0
 	golang.org/x/net v0.0.0-20210924151903-3ad01bbaa167 // indirect
-	golang.org/x/sys v0.0.0-20210817190340-bfb29a6856f2 // indirect
-	golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba // indirect
-	google.golang.org/genproto v0.0.0-20210602131652-f16073e35f0c // indirect
+	golang.org/x/sys v0.0.0-20210927052749-1cf2251ac284 // indirect
+	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect
+	google.golang.org/genproto v0.0.0-20210924002016-3dee208752a0 // indirect
 	gopkg.in/dc0d/tinykv.v4 v4.0.1
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )
 
 require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/docker/go-units v0.4.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
@@ -27,6 +28,8 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	google.golang.org/grpc v1.38.0 // indirect
-	google.golang.org/protobuf v1.26.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/objx v0.3.0 // indirect
+	google.golang.org/grpc v1.41.0 // indirect
+	google.golang.org/protobuf v1.27.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -67,6 +67,7 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alexflint/go-filemutex v0.0.0-20171022225611-72bdc8eae2ae/go.mod h1:CgnQgUtFrFz9mxFNtED3jI5tLDjKlOM+oUF/sTk6ps0=
+github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/aws/aws-sdk-go v1.15.11/go.mod h1:mFuSZ37Z9YOHbQEwBWztmVzqXrEkub65tZoCYDt7FT0=
@@ -101,6 +102,8 @@ github.com/cilium/ebpf v0.6.2/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJ
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
+github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
+github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/containerd/aufs v0.0.0-20200908144142-dab0cbea06f4/go.mod h1:nukgQABAEopAHvB6j7cnP5zJ+/3aVcE7hCYqvIwAHyE=
 github.com/containerd/aufs v0.0.0-20201003224125-76a6863f2989/go.mod h1:AkGGQs9NM2vtYHaUen+NljV0/baGCAPELGm2q9ZXpWU=
@@ -241,7 +244,9 @@ github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
-github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
+github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
+github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.mod h1:hliV/p42l8fGbc6Y9bQ70uLwIvmJyVE5k4iMKlh8wCQ=
+github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.mod h1:AFq3mo9L8Lqqiid3OhADV3RfLJnjiw63cSpi+fDTRC0=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
@@ -344,8 +349,8 @@ github.com/googleapis/gnostic v0.4.1/go.mod h1:LRhVm6pbyptWbWbuZ38d1eyptfvIytN3i
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/handlers v0.0.0-20150720190736-60c7bfde3e33/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/OAirnOIQ=
 github.com/gorilla/mux v1.7.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
-github.com/gorilla/mux v1.7.3 h1:gnP5JzjVOuiZD07fKKToCAOjS0yOpj/qPETTXCCS6hw=
-github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
+github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
+github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
@@ -355,6 +360,7 @@ github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
+github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/hashicorp/errwrap v0.0.0-20141028054710-7554cd9344ce/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-multierror v0.0.0-20161216184304-ed905158d874/go.mod h1:JMRHfdO9jKNzS/+BTlxCjKNQHg/jZAft8U7LloJvN7I=
@@ -392,9 +398,11 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxv
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
+github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
@@ -511,6 +519,7 @@ github.com/prometheus/procfs v0.2.0/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4O
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
+github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/safchain/ethtool v0.0.0-20190326074333-42ed695e3de8/go.mod h1:Z0q5wiBQGYcxhMZ6gUqHn6pYNLypFAvaL3UvgZLR0U4=
@@ -548,6 +557,8 @@ github.com/stretchr/objx v0.0.0-20180129172003-8a3f7159479f/go.mod h1:HFkY916IF+
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
+github.com/stretchr/objx v0.3.0 h1:NGXK3lHquSN08v5vWalVI/L8XU9hdzE/G6xsrze47As=
+github.com/stretchr/objx v0.3.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v0.0.0-20180303142811-b89eecf5ca5d/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
@@ -582,7 +593,6 @@ github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
-github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yvasiyarov/go-metrics v0.0.0-20140926110328-57bccd1ccd43/go.mod h1:aX5oPXxHm3bOH+xeAttToC8pqch2ScQN/JoXYupl6xs=
 github.com/yvasiyarov/gorelic v0.0.0-20141212073537-a9bba5b9ab50/go.mod h1:NUSPSUX/bi6SeDMUh6brw0nXpxHnc96TguQh0+r/ssA=
 github.com/yvasiyarov/newrelic_platform_go v0.0.0-20140908184405-b21fdbd4370f/go.mod h1:GlGEuHIJweS1mbCqG+7vt2nvWLzLLnRHbXz5JKd/Qbg=
@@ -595,6 +605,7 @@ go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.opencensus.io v0.22.3/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
+go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
@@ -634,7 +645,6 @@ golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHl
 golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f/go.mod h1:5qLYkcX4OjUUV8bRuDixDT3tpyyb+LUpUlRWLxfhWrs=
 golang.org/x/lint v0.0.0-20200130185559-910be7a94367/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
-golang.org/x/lint v0.0.0-20210508222113-6edffad5e616/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
 golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028/go.mod h1:E/iHnbuqvinMTCcRqshq8CkpyQDoeVncDDYHnLhea+o=
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
@@ -643,7 +653,6 @@ golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzB
 golang.org/x/mod v0.1.1-0.20191107180719-034126e5016b/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -673,6 +682,7 @@ golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20200301022130-244492dfa37a/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
+golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20201006153459-a7d1128ccaa0/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
@@ -695,7 +705,6 @@ golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -759,8 +768,8 @@ golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210426230700-d19ff857e887/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20210817190340-bfb29a6856f2 h1:c8PlLMqBbOHoqtjteWm5/kbe6rNY2pbRfbIMVnepueo=
-golang.org/x/sys v0.0.0-20210817190340-bfb29a6856f2/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210927052749-1cf2251ac284 h1:lBPNCmq8u4zFP3huKCmUQ2Fx8kcY4X+O12UgGnyKsrg=
+golang.org/x/sys v0.0.0-20210927052749-1cf2251ac284/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -776,8 +785,8 @@ golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxb
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
-golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba h1:O8mE0/t419eoIwhTFpKVkHiTs/Igowgfkj25AcZrtiE=
-golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac h1:7zkz7BUtwNFFqcowJ+RIgu2MaV/MapERkDIy+mwPyjs=
+golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20181030221726-6c7e314b6563/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
@@ -815,7 +824,6 @@ golang.org/x/tools v0.0.0-20200224181240-023911ca70b2/go.mod h1:TB2adYChydJhpapK
 golang.org/x/tools v0.0.0-20200304193943-95d2e580d8eb/go.mod h1:o4KQGtdN14AW+yjsvvwRTJJuXz8XRtIHtEnmAXLyFUw=
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
-golang.org/x/tools v0.1.2/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -858,10 +866,11 @@ google.golang.org/genproto v0.0.0-20200204135345-fa8e72b47b90/go.mod h1:GmwEX6Z4
 google.golang.org/genproto v0.0.0-20200212174721-66ed5ce911ce/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/genproto v0.0.0-20200224152610-e50cd9704f63/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/genproto v0.0.0-20200305110556-506484158171/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
+google.golang.org/genproto v0.0.0-20200513103714-09dca8ec2884/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
 google.golang.org/genproto v0.0.0-20201110150050-8816d57aaa9a/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
-google.golang.org/genproto v0.0.0-20210602131652-f16073e35f0c h1:wtujag7C+4D6KMoulW9YauvK2lgdvCMS260jsqqBXr0=
-google.golang.org/genproto v0.0.0-20210602131652-f16073e35f0c/go.mod h1:UODoCrxHCcBojKKwX1terBiRUaqAsFqJiF615XL43r0=
+google.golang.org/genproto v0.0.0-20210924002016-3dee208752a0 h1:5Tbluzus3QxoAJx4IefGt1W0HQZW4nuMrVk684jI74Q=
+google.golang.org/genproto v0.0.0-20210924002016-3dee208752a0/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
 google.golang.org/grpc v0.0.0-20160317175043-d3ddb4469d5a/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
@@ -875,9 +884,12 @@ google.golang.org/grpc v1.26.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8
 google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.27.1/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.30.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
+google.golang.org/grpc v1.33.1/go.mod h1:fr5YgcSWrqhRRxogOsw7RzIpsmvOZ6IcH4kBYTpR3n0=
 google.golang.org/grpc v1.33.2/go.mod h1:JMHMWHQWaTccqQQlmk3MJZS+GWXOdAesneDmEnv2fbc=
-google.golang.org/grpc v1.38.0 h1:/9BgsAsa5nWe26HqOlvlgJnqBuktYOLCgjCPqsa56W0=
-google.golang.org/grpc v1.38.0/go.mod h1:NREThFqKR1f3iQ6oBuvc5LadQuXVGo9rkm5ZGrQdJfM=
+google.golang.org/grpc v1.36.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
+google.golang.org/grpc v1.40.0/go.mod h1:ogyxbiOoUXAkP+4+xa6PZSE9DZgIHtSpzjDTB9KAK34=
+google.golang.org/grpc v1.41.0 h1:f+PlOh7QV4iIJkPrx5NQ7qaNGFQ3OTse67yaDHfju4E=
+google.golang.org/grpc v1.41.0/go.mod h1:U3l9uK9J0sini8mHphKoXyaqDA/8VyGnDee1zzIUK6k=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=
@@ -889,13 +901,15 @@ google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpAD
 google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGjtUeSXeh4=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
-google.golang.org/protobuf v1.26.0 h1:bxAC2xTBsZGibn2RTntX0oH50xLsqy1OxA9tTL3p/lk=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
+google.golang.org/protobuf v1.27.1 h1:SnqbnDw1V7RiZcXPx5MEeqPv2s79L9i7BJUlG/+RurQ=
+google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20141024133853-64131543e789/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/cheggaaa/pb.v1 v1.0.25/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
 gopkg.in/dc0d/tinykv.v4 v4.0.1 h1:/L+MKftOW3mTXDk0oYLYoGx2+rfIMh4hOCc5dYj0/9g=
@@ -913,6 +927,7 @@ gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWD
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.5/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/main.go
+++ b/main.go
@@ -26,30 +26,33 @@ func main() {
 
 	flag.Parse()
 
-	cli, err := client.NewClientWithOpts()
-	if err != nil {
-		log.Fatal(fmt.Errorf("%+v", "Could not connect to docker API"))
-	}
-
 	dockerScaler := getDockerScaler(*swarmMode)
 
 	fmt.Printf("Server listening on port 10000, swarmMode: %t\n", *swarmMode)
-	http.HandleFunc("/", onDemand(cli, dockerScaler))
+	http.HandleFunc("/", onDemand(dockerScaler))
 	log.Fatal(http.ListenAndServe(":10000", nil))
 }
 
 func getDockerScaler(swarmMode bool) scaler.Scaler {
-	if swarmMode {
-		return scaler.DockerSwarmScaler{}
+	cli, err := client.NewClientWithOpts()
+	if err != nil {
+		log.Fatal(fmt.Errorf("%+v", "Could not connect to docker API"))
 	}
-	return scaler.DockerClassicScaler{}
+	if swarmMode {
+		return &scaler.DockerSwarmScaler{
+			Client: cli,
+		}
+	}
+	return &scaler.DockerClassicScaler{
+		Client: cli,
+	}
 }
 
-func onDemand(client *client.Client, scaler scaler.Scaler) func(w http.ResponseWriter, r *http.Request) {
+func onDemand(scaler scaler.Scaler) func(w http.ResponseWriter, r *http.Request) {
 
 	store := tinykv.New(time.Second*20, func(key string, _ interface{}) {
 		// Auto scale down after timeout
-		scaler.ScaleDown(client, key)
+		scaler.ScaleDown(key)
 	})
 
 	return func(rw http.ResponseWriter, r *http.Request) {
@@ -75,13 +78,11 @@ func onDemand(client *client.Client, scaler scaler.Scaler) func(w http.ResponseW
 			return
 		}
 
-		replicas := uint64(1)
-
 		requestState, exists := store.Get(name)
 
 		// 1. Check against the current state
 		if !exists || requestState.(OnDemandRequestState).State != "started" {
-			if scaler.IsUp(client, name) {
+			if scaler.IsUp(name) {
 				requestState = OnDemandRequestState{
 					State: "started",
 					Name:  name,
@@ -91,7 +92,7 @@ func onDemand(client *client.Client, scaler scaler.Scaler) func(w http.ResponseW
 					State: "starting",
 					Name:  name,
 				}
-				scaler.ScaleUp(client, name, &replicas)
+				scaler.ScaleUp(name)
 			}
 		}
 

--- a/main_test.go
+++ b/main_test.go
@@ -4,21 +4,19 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
-
-	"github.com/docker/docker/client"
 )
 
 type ScalerMock struct {
 	isUp bool
 }
 
-func (s ScalerMock) IsUp(client *client.Client, name string) bool {
+func (s ScalerMock) IsUp(name string) bool {
 	return s.isUp
 }
 
-func (ScalerMock) ScaleUp(client *client.Client, name string, replicas *uint64) {}
+func (ScalerMock) ScaleUp(name string) error { return nil }
 
-func (ScalerMock) ScaleDown(client *client.Client, name string) {}
+func (ScalerMock) ScaleDown(name string) error { return nil }
 
 func TestOndemand_ServeHTTP(t *testing.T) {
 	testCases := []struct {
@@ -52,7 +50,7 @@ func TestOndemand_ServeHTTP(t *testing.T) {
 			request := httptest.NewRequest("GET", "/?name=whoami&timeout=5m", nil)
 			responseRecorder := httptest.NewRecorder()
 
-			onDemandHandler := onDemand(nil, test.scaler)
+			onDemandHandler := onDemand(test.scaler)
 			onDemandHandler(responseRecorder, request)
 
 			body := responseRecorder.Body.String()

--- a/pkg/scaler/docker_classic_test.go
+++ b/pkg/scaler/docker_classic_test.go
@@ -1,0 +1,363 @@
+package scaler
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/acouvreur/traefik-ondemand-service/pkg/scaler/mocks"
+	"github.com/docker/docker/api/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestDockerClassicScaler_ScaleUp(t *testing.T) {
+	type fields struct {
+		Client *mocks.ContainerAPIClientMock
+	}
+	type args struct {
+		name string
+	}
+	tests := []struct {
+		name          string
+		fields        fields
+		args          args
+		containerList []types.Container
+		err           error
+	}{
+		{
+			name: "start nginx container",
+			fields: fields{
+				Client: mocks.NewContainerAPIClientMock(),
+			},
+			args: args{
+				name: "nginx",
+			},
+			containerList: []types.Container{
+				{
+					Names: []string{"nginx"},
+				},
+			},
+			err: nil,
+		},
+		{
+			name: "container nginx was not found",
+			fields: fields{
+				Client: mocks.NewContainerAPIClientMock(),
+			},
+			args: args{
+				name: "nginx",
+			},
+			containerList: []types.Container{},
+			err:           errors.New("container with name nginx was not found"),
+		},
+		{
+			name: "multiple containers with name nginx were found",
+			fields: fields{
+				Client: mocks.NewContainerAPIClientMock(),
+			},
+			args: args{
+				name: "nginx",
+			},
+			containerList: []types.Container{
+				{
+					Names: []string{"nginx1"},
+				},
+				{
+					Names: []string{"nginx2"},
+				},
+			},
+			err: errors.New("multiple containers (2) with name nginx were found: [{ [nginx1]    0 [] 0 0 map[]   {} <nil> []} { [nginx2]    0 [] 0 0 map[]   {} <nil> []}]"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scaler := &DockerClassicScaler{
+				Client: tt.fields.Client,
+			}
+
+			tt.fields.Client.On("ContainerList", mock.Anything, mock.Anything).Return(tt.containerList, nil)
+			tt.fields.Client.On("ContainerStart", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+			err := scaler.ScaleUp(tt.args.name)
+
+			assert.EqualValues(t, tt.err, err)
+		})
+	}
+}
+
+func TestDockerClassicScaler_ScaleDown(t *testing.T) {
+	type fields struct {
+		Client *mocks.ContainerAPIClientMock
+	}
+	type args struct {
+		name string
+	}
+	tests := []struct {
+		name          string
+		fields        fields
+		args          args
+		containerList []types.Container
+		err           error
+	}{
+		{
+			name: "start nginx container",
+			fields: fields{
+				Client: mocks.NewContainerAPIClientMock(),
+			},
+			args: args{
+				name: "nginx",
+			},
+			containerList: []types.Container{
+				{
+					Names: []string{"nginx"},
+				},
+			},
+			err: nil,
+		},
+		{
+			name: "container nginx was not found",
+			fields: fields{
+				Client: mocks.NewContainerAPIClientMock(),
+			},
+			args: args{
+				name: "nginx",
+			},
+			containerList: []types.Container{},
+			err:           errors.New("container with name nginx was not found"),
+		},
+		{
+			name: "multiple containers with name nginx were found",
+			fields: fields{
+				Client: mocks.NewContainerAPIClientMock(),
+			},
+			args: args{
+				name: "nginx",
+			},
+			containerList: []types.Container{
+				{
+					Names: []string{"nginx1"},
+				},
+				{
+					Names: []string{"nginx2"},
+				},
+			},
+			err: errors.New("multiple containers (2) with name nginx were found: [{ [nginx1]    0 [] 0 0 map[]   {} <nil> []} { [nginx2]    0 [] 0 0 map[]   {} <nil> []}]"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scaler := &DockerClassicScaler{
+				Client: tt.fields.Client,
+			}
+
+			tt.fields.Client.On("ContainerList", mock.Anything, mock.Anything).Return(tt.containerList, nil)
+			tt.fields.Client.On("ContainerStop", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+			err := scaler.ScaleDown(tt.args.name)
+
+			assert.EqualValues(t, tt.err, err)
+		})
+	}
+}
+
+func TestDockerClassicScaler_IsUp(t *testing.T) {
+	type fields struct {
+		Client *mocks.ContainerAPIClientMock
+	}
+	type args struct {
+		name string
+	}
+	tests := []struct {
+		name          string
+		fields        fields
+		args          args
+		containerList []types.Container
+		containerSpec types.ContainerJSON
+		want          bool
+	}{
+		{
+			name: "nginx container is started without healthcheck",
+			fields: fields{
+				Client: mocks.NewContainerAPIClientMock(),
+			},
+			args: args{
+				name: "nginx",
+			},
+			containerList: []types.Container{
+				{
+					Names: []string{"nginx"},
+				},
+			},
+			containerSpec: types.ContainerJSON{
+				ContainerJSONBase: &types.ContainerJSONBase{
+					State: &types.ContainerState{
+						Running: true,
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "nginx container is not running without healthcheck",
+			fields: fields{
+				Client: mocks.NewContainerAPIClientMock(),
+			},
+			args: args{
+				name: "nginx",
+			},
+			containerList: []types.Container{
+				{
+					Names: []string{"nginx"},
+				},
+			},
+			containerSpec: types.ContainerJSON{
+				ContainerJSONBase: &types.ContainerJSONBase{
+					State: &types.ContainerState{
+						Running: false,
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "nginx container is started but not healthy",
+			fields: fields{
+				Client: mocks.NewContainerAPIClientMock(),
+			},
+			args: args{
+				name: "nginx",
+			},
+			containerList: []types.Container{
+				{
+					Names: []string{"nginx"},
+				},
+			},
+			containerSpec: types.ContainerJSON{
+				ContainerJSONBase: &types.ContainerJSONBase{
+					State: &types.ContainerState{
+						Running: true,
+						Health: &types.Health{
+							Status: "starting",
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "nginx container is started and healthy",
+			fields: fields{
+				Client: mocks.NewContainerAPIClientMock(),
+			},
+			args: args{
+				name: "nginx",
+			},
+			containerList: []types.Container{
+				{
+					Names: []string{"nginx"},
+				},
+			},
+			containerSpec: types.ContainerJSON{
+				ContainerJSONBase: &types.ContainerJSONBase{
+					State: &types.ContainerState{
+						Running: true,
+						Health: &types.Health{
+							Status: "healthy",
+						},
+					},
+				},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scaler := &DockerClassicScaler{
+				Client: tt.fields.Client,
+			}
+
+			tt.fields.Client.On("ContainerList", mock.Anything, mock.Anything).Return(tt.containerList, nil)
+			tt.fields.Client.On("ContainerInspect", mock.Anything, mock.Anything).Return(tt.containerSpec, nil)
+
+			got := scaler.IsUp(tt.args.name)
+
+			assert.EqualValues(t, tt.want, got)
+		})
+	}
+}
+
+func TestDockerClassicScaler_GetContainerByName(t *testing.T) {
+	type fields struct {
+		Client *mocks.ContainerAPIClientMock
+	}
+	type args struct {
+		name string
+		ctx  context.Context
+	}
+	tests := []struct {
+		name          string
+		fields        fields
+		args          args
+		containerList []types.Container
+		err           error
+	}{
+		{
+			name: "start nginx container",
+			fields: fields{
+				Client: mocks.NewContainerAPIClientMock(),
+			},
+			args: args{
+				name: "nginx",
+			},
+			containerList: []types.Container{
+				{
+					Names: []string{"nginx"},
+				},
+			},
+			err: nil,
+		},
+		{
+			name: "container nginx was not found",
+			fields: fields{
+				Client: mocks.NewContainerAPIClientMock(),
+			},
+			args: args{
+				name: "nginx",
+			},
+			containerList: []types.Container{},
+			err:           errors.New("container with name nginx was not found"),
+		},
+		{
+			name: "multiple containers with name nginx were found",
+			fields: fields{
+				Client: mocks.NewContainerAPIClientMock(),
+			},
+			args: args{
+				name: "nginx",
+			},
+			containerList: []types.Container{
+				{
+					Names: []string{"nginx1"},
+				},
+				{
+					Names: []string{"nginx2"},
+				},
+			},
+			err: errors.New("multiple containers (2) with name nginx were found: [{ [nginx1]    0 [] 0 0 map[]   {} <nil> []} { [nginx2]    0 [] 0 0 map[]   {} <nil> []}]"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scaler := &DockerClassicScaler{
+				Client: tt.fields.Client,
+			}
+
+			tt.fields.Client.On("ContainerList", mock.Anything, mock.Anything).Return(tt.containerList, nil)
+
+			_, err := scaler.GetContainerByName(tt.args.name, tt.args.ctx)
+
+			assert.EqualValues(t, tt.err, err)
+		})
+	}
+}

--- a/pkg/scaler/docker_swarm.go
+++ b/pkg/scaler/docker_swarm.go
@@ -11,41 +11,49 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-type DockerSwarmScaler struct{}
+type DockerSwarmScaler struct {
+	Client client.ServiceAPIClient
+}
 
-func (DockerSwarmScaler) ScaleUp(client *client.Client, name string, replicas *uint64) {
-	log.Infof("scaling up %s to %d", name, *replicas)
+func NewDockerSwarmScaler() *DockerSwarmScaler {
+	return &DockerSwarmScaler{}
+}
+
+func (scaler *DockerSwarmScaler) ScaleUp(name string) error {
+	log.Infof("scaling up %s to %d", name, &zeroreplicas)
 	ctx := context.Background()
-	service, err := GetServiceByName(client, name, ctx)
+	service, err := scaler.GetServiceByName(name, ctx)
 
 	if err != nil {
 		log.Error(err.Error())
-		return
+		return err
 	}
 
 	service.Spec.Mode.Replicated = &swarm.ReplicatedService{
-		Replicas: replicas,
+		Replicas: &zeroreplicas,
 	}
-	response, err := client.ServiceUpdate(ctx, service.ID, service.Meta.Version, service.Spec, types.ServiceUpdateOptions{})
+	response, err := scaler.Client.ServiceUpdate(ctx, service.ID, service.Meta.Version, service.Spec, types.ServiceUpdateOptions{})
 
 	if err != nil {
 		log.Error(err.Error())
-		return
+		return err
 	}
 
 	if len(response.Warnings) > 0 {
 		log.Warnf("received scaling up service %s: %v", name, response.Warnings)
 	}
+
+	return nil
 }
 
-func (DockerSwarmScaler) ScaleDown(client *client.Client, name string) {
+func (scaler *DockerSwarmScaler) ScaleDown(name string) error {
 	log.Infof("scaling down %s to 0", name)
 	ctx := context.Background()
-	service, err := GetServiceByName(client, name, ctx)
+	service, err := scaler.GetServiceByName(name, ctx)
 
 	if err != nil {
 		log.Error(err.Error())
-		return
+		return err
 	}
 
 	replicas := uint64(0)
@@ -53,21 +61,23 @@ func (DockerSwarmScaler) ScaleDown(client *client.Client, name string) {
 	service.Spec.Mode.Replicated = &swarm.ReplicatedService{
 		Replicas: &replicas,
 	}
-	response, err := client.ServiceUpdate(ctx, service.ID, service.Meta.Version, service.Spec, types.ServiceUpdateOptions{})
+	response, err := scaler.Client.ServiceUpdate(ctx, service.ID, service.Meta.Version, service.Spec, types.ServiceUpdateOptions{})
 
 	if err != nil {
 		log.Error(err.Error())
-		return
+		return err
 	}
 
 	if len(response.Warnings) > 0 {
 		log.Warnf("received scaling up service %s: %v", name, response.Warnings)
 	}
+
+	return nil
 }
 
-func (DockerSwarmScaler) IsUp(client *client.Client, name string) bool {
+func (scaler *DockerSwarmScaler) IsUp(name string) bool {
 	ctx := context.Background()
-	service, err := GetServiceByName(client, name, ctx)
+	service, err := scaler.GetServiceByName(name, ctx)
 
 	if err != nil {
 		log.Error(err.Error())
@@ -77,13 +87,13 @@ func (DockerSwarmScaler) IsUp(client *client.Client, name string) bool {
 	return *service.Spec.Mode.Replicated.Replicas > 0
 }
 
-func GetServiceByName(client *client.Client, name string, ctx context.Context) (*swarm.Service, error) {
+func (scaler *DockerSwarmScaler) GetServiceByName(name string, ctx context.Context) (*swarm.Service, error) {
 	opts := types.ServiceListOptions{
 		Filters: filters.NewArgs(),
 	}
 	opts.Filters.Add("name", name)
 
-	services, err := client.ServiceList(ctx, opts)
+	services, err := scaler.Client.ServiceList(ctx, opts)
 
 	if err != nil {
 		return nil, err

--- a/pkg/scaler/docker_swarm_test.go
+++ b/pkg/scaler/docker_swarm_test.go
@@ -5,81 +5,258 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/acouvreur/traefik-ondemand-service/pkg/scaler/mocks"
+	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/client"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 func TestDockerSwarmScaler_ScaleUp(t *testing.T) {
 	type fields struct {
-		Client client.ServiceAPIClient
+		Client *mocks.ServiceAPIClientMock
 	}
 	type args struct {
 		name string
 	}
 	tests := []struct {
-		name   string
-		fields fields
-		args   args
+		name        string
+		fields      fields
+		args        args
+		serviceList []swarm.Service
+		want        swarm.Service
+		err         error
 	}{
-		// TODO: Add test cases.
+		{
+			name: "scale nginx service to 1 replica",
+			fields: fields{
+				Client: mocks.NewServiceAPIClientMock(),
+			},
+			args: args{
+				name: "nginx",
+			},
+			serviceList: []swarm.Service{
+				{
+					ID:   "nginx_service",
+					Meta: swarm.Meta{Version: swarm.Version{}},
+					Spec: swarm.ServiceSpec{
+						Mode: swarm.ServiceMode{
+							Replicated: &swarm.ReplicatedService{
+								Replicas: &zeroreplicas,
+							},
+						},
+					},
+				},
+			},
+			want: swarm.Service{
+				ID:   "nginx_service",
+				Meta: swarm.Meta{Version: swarm.Version{}},
+				Spec: swarm.ServiceSpec{
+					Mode: swarm.ServiceMode{
+						Replicated: &swarm.ReplicatedService{
+							Replicas: &onereplicas,
+						},
+					},
+				},
+			},
+			err: nil,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			scaler := &DockerSwarmScaler{
 				Client: tt.fields.Client,
 			}
+
+			tt.fields.Client.On("ServiceList", mock.Anything, mock.Anything).Return(tt.serviceList, nil)
+			tt.fields.Client.On("ServiceUpdate", mock.Anything, tt.want.ID, tt.want.Meta.Version, tt.want.Spec, mock.Anything).Return(types.ServiceUpdateResponse{
+				Warnings: []string{},
+			}, nil)
+
 			scaler.ScaleUp(tt.args.name)
+
+			tt.fields.Client.AssertExpectations(t)
 		})
 	}
 }
 
 func TestDockerSwarmScaler_ScaleDown(t *testing.T) {
 	type fields struct {
-		Client client.ServiceAPIClient
+		Client *mocks.ServiceAPIClientMock
 	}
 	type args struct {
 		name string
 	}
 	tests := []struct {
-		name   string
-		fields fields
-		args   args
+		name        string
+		fields      fields
+		args        args
+		serviceList []swarm.Service
+		want        swarm.Service
+		err         error
 	}{
-		// TODO: Add test cases.
+		{
+			name: "scale nginx service to 1 replica",
+			fields: fields{
+				Client: mocks.NewServiceAPIClientMock(),
+			},
+			args: args{
+				name: "nginx",
+			},
+			serviceList: []swarm.Service{
+				{
+					ID:   "nginx_service",
+					Meta: swarm.Meta{Version: swarm.Version{}},
+					Spec: swarm.ServiceSpec{
+						Mode: swarm.ServiceMode{
+							Replicated: &swarm.ReplicatedService{
+								Replicas: &onereplicas,
+							},
+						},
+					},
+				},
+			},
+			want: swarm.Service{
+				ID:   "nginx_service",
+				Meta: swarm.Meta{Version: swarm.Version{}},
+				Spec: swarm.ServiceSpec{
+					Mode: swarm.ServiceMode{
+						Replicated: &swarm.ReplicatedService{
+							Replicas: &zeroreplicas,
+						},
+					},
+				},
+			},
+			err: nil,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			scaler := &DockerSwarmScaler{
 				Client: tt.fields.Client,
 			}
+
+			tt.fields.Client.On("ServiceList", mock.Anything, mock.Anything).Return(tt.serviceList, nil)
+			tt.fields.Client.On("ServiceUpdate", mock.Anything, tt.want.ID, tt.want.Meta.Version, tt.want.Spec, mock.Anything).Return(types.ServiceUpdateResponse{
+				Warnings: []string{},
+			}, nil)
+
 			scaler.ScaleDown(tt.args.name)
+
+			tt.fields.Client.AssertExpectations(t)
 		})
 	}
 }
 
 func TestDockerSwarmScaler_IsUp(t *testing.T) {
 	type fields struct {
-		Client client.ServiceAPIClient
+		Client *mocks.ServiceAPIClientMock
 	}
 	type args struct {
 		name string
 	}
 	tests := []struct {
-		name   string
-		fields fields
-		args   args
-		want   bool
+		name        string
+		fields      fields
+		args        args
+		serviceList []swarm.Service
+		want        bool
 	}{
-		// TODO: Add test cases.
+		{
+			name: "service nginx is 0/0",
+			fields: fields{
+				Client: mocks.NewServiceAPIClientMock(),
+			},
+			args: args{
+				name: "nginx",
+			},
+			serviceList: []swarm.Service{
+				{
+					ID:   "nginx_service",
+					Meta: swarm.Meta{Version: swarm.Version{}},
+					Spec: swarm.ServiceSpec{
+						Mode: swarm.ServiceMode{
+							Replicated: &swarm.ReplicatedService{
+								Replicas: &zeroreplicas,
+							},
+						},
+					},
+					ServiceStatus: &swarm.ServiceStatus{
+						RunningTasks: 0,
+						DesiredTasks: 0,
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "service nginx is 1/1",
+			fields: fields{
+				Client: mocks.NewServiceAPIClientMock(),
+			},
+			args: args{
+				name: "nginx",
+			},
+			serviceList: []swarm.Service{
+				{
+					ID:   "nginx_service",
+					Meta: swarm.Meta{Version: swarm.Version{}},
+					Spec: swarm.ServiceSpec{
+						Mode: swarm.ServiceMode{
+							Replicated: &swarm.ReplicatedService{
+								Replicas: &zeroreplicas,
+							},
+						},
+					},
+					ServiceStatus: &swarm.ServiceStatus{
+						RunningTasks: 1,
+						DesiredTasks: 1,
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "service nginx is 0/1",
+			fields: fields{
+				Client: mocks.NewServiceAPIClientMock(),
+			},
+			args: args{
+				name: "nginx",
+			},
+			serviceList: []swarm.Service{
+				{
+					ID:   "nginx_service",
+					Meta: swarm.Meta{Version: swarm.Version{}},
+					Spec: swarm.ServiceSpec{
+						Mode: swarm.ServiceMode{
+							Replicated: &swarm.ReplicatedService{
+								Replicas: &zeroreplicas,
+							},
+						},
+					},
+					ServiceStatus: &swarm.ServiceStatus{
+						RunningTasks: 0,
+						DesiredTasks: 1,
+					},
+				},
+			},
+			want: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			scaler := &DockerSwarmScaler{
 				Client: tt.fields.Client,
 			}
-			if got := scaler.IsUp(tt.args.name); got != tt.want {
-				t.Errorf("DockerSwarmScaler.IsUp() = %v, want %v", got, tt.want)
-			}
+
+			tt.fields.Client.On("ServiceList", mock.Anything, mock.Anything).Return(tt.serviceList, nil)
+
+			got := scaler.IsUp(tt.args.name)
+
+			assert.EqualValues(t, tt.want, got)
+			tt.fields.Client.AssertExpectations(t)
 		})
 	}
 }

--- a/pkg/scaler/docker_swarm_test.go
+++ b/pkg/scaler/docker_swarm_test.go
@@ -1,0 +1,119 @@
+package scaler
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/client"
+)
+
+func TestDockerSwarmScaler_ScaleUp(t *testing.T) {
+	type fields struct {
+		Client client.ServiceAPIClient
+	}
+	type args struct {
+		name string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scaler := &DockerSwarmScaler{
+				Client: tt.fields.Client,
+			}
+			scaler.ScaleUp(tt.args.name)
+		})
+	}
+}
+
+func TestDockerSwarmScaler_ScaleDown(t *testing.T) {
+	type fields struct {
+		Client client.ServiceAPIClient
+	}
+	type args struct {
+		name string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scaler := &DockerSwarmScaler{
+				Client: tt.fields.Client,
+			}
+			scaler.ScaleDown(tt.args.name)
+		})
+	}
+}
+
+func TestDockerSwarmScaler_IsUp(t *testing.T) {
+	type fields struct {
+		Client client.ServiceAPIClient
+	}
+	type args struct {
+		name string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   bool
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scaler := &DockerSwarmScaler{
+				Client: tt.fields.Client,
+			}
+			if got := scaler.IsUp(tt.args.name); got != tt.want {
+				t.Errorf("DockerSwarmScaler.IsUp() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDockerSwarmScaler_GetServiceByName(t *testing.T) {
+	type fields struct {
+		Client client.ServiceAPIClient
+	}
+	type args struct {
+		name string
+		ctx  context.Context
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    *swarm.Service
+		wantErr bool
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scaler := &DockerSwarmScaler{
+				Client: tt.fields.Client,
+			}
+			got, err := scaler.GetServiceByName(tt.args.name, tt.args.ctx)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("DockerSwarmScaler.GetServiceByName() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("DockerSwarmScaler.GetServiceByName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/scaler/mocks/client_mock.go
+++ b/pkg/scaler/mocks/client_mock.go
@@ -1,0 +1,39 @@
+package mocks
+
+import (
+	"context"
+	"time"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/client"
+	"github.com/stretchr/testify/mock"
+)
+
+type ContainerAPIClientMock struct {
+	client.ContainerAPIClient
+	mock.Mock
+}
+
+func NewContainerAPIClientMock() *ContainerAPIClientMock {
+	return &ContainerAPIClientMock{}
+}
+
+func (client *ContainerAPIClientMock) ContainerStart(ctx context.Context, container string, options types.ContainerStartOptions) error {
+	args := client.Mock.Called(ctx, container, options)
+	return args.Error(0)
+}
+
+func (client *ContainerAPIClientMock) ContainerStop(ctx context.Context, container string, timeout *time.Duration) error {
+	args := client.Mock.Called(ctx, container, timeout)
+	return args.Error(0)
+}
+
+func (client *ContainerAPIClientMock) ContainerInspect(ctx context.Context, container string) (types.ContainerJSON, error) {
+	args := client.Mock.Called(ctx, container)
+	return args.Get(0).(types.ContainerJSON), args.Error(1)
+}
+
+func (client *ContainerAPIClientMock) ContainerList(ctx context.Context, options types.ContainerListOptions) ([]types.Container, error) {
+	args := client.Mock.Called(ctx, options)
+	return args.Get(0).([]types.Container), args.Error(1)
+}

--- a/pkg/scaler/mocks/client_mock.go
+++ b/pkg/scaler/mocks/client_mock.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/swarm"
 	"github.com/docker/docker/client"
 	"github.com/stretchr/testify/mock"
 )
@@ -36,4 +37,23 @@ func (client *ContainerAPIClientMock) ContainerInspect(ctx context.Context, cont
 func (client *ContainerAPIClientMock) ContainerList(ctx context.Context, options types.ContainerListOptions) ([]types.Container, error) {
 	args := client.Mock.Called(ctx, options)
 	return args.Get(0).([]types.Container), args.Error(1)
+}
+
+type ServiceAPIClientMock struct {
+	client.ServiceAPIClient
+	mock.Mock
+}
+
+func NewServiceAPIClientMock() *ServiceAPIClientMock {
+	return &ServiceAPIClientMock{}
+}
+
+func (client *ServiceAPIClientMock) ServiceUpdate(ctx context.Context, serviceID string, version swarm.Version, service swarm.ServiceSpec, options types.ServiceUpdateOptions) (types.ServiceUpdateResponse, error) {
+	args := client.Mock.Called(ctx, serviceID, version, service, options)
+	return args.Get(0).(types.ServiceUpdateResponse), args.Error(1)
+}
+
+func (client *ServiceAPIClientMock) ServiceList(ctx context.Context, options types.ServiceListOptions) ([]swarm.Service, error) {
+	args := client.Mock.Called(ctx, options)
+	return args.Get(0).([]swarm.Service), args.Error(1)
 }

--- a/pkg/scaler/scaler.go
+++ b/pkg/scaler/scaler.go
@@ -1,9 +1,10 @@
 package scaler
 
-import "github.com/docker/docker/client"
+var onereplicas = uint64(1)
+var zeroreplicas = uint64(0)
 
 type Scaler interface {
-	ScaleUp(client *client.Client, name string, replicas *uint64)
-	ScaleDown(client *client.Client, name string)
-	IsUp(client *client.Client, name string) bool
+	ScaleUp(name string) error
+	ScaleDown(name string) error
+	IsUp(name string) bool
 }


### PR DESCRIPTION
Docker classic IsUp will return false when the container defines a healthcheck and is not healthy, otherwise as soon as it's started it's good.
Docker swarm will check that the number of required tasks is higher than 1, and that the number of running tasks matches the number of desired tasks.
A task is not running when it defines a healthcheck and is not healthy.