### PR TITLE
fix(swarm): add an extra wait of 5 seconds to consider a service up

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,4 +30,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           npm i -G semantic-release @semantic-release/exec
-          npx semantic-release -b main
+          npx semantic-release

--- a/pkg/scaler/mocks/client_mock.go
+++ b/pkg/scaler/mocks/client_mock.go
@@ -57,3 +57,8 @@ func (client *ServiceAPIClientMock) ServiceList(ctx context.Context, options typ
 	args := client.Mock.Called(ctx, options)
 	return args.Get(0).([]swarm.Service), args.Error(1)
 }
+
+func (client *ServiceAPIClientMock) TaskList(ctx context.Context, options types.TaskListOptions) ([]swarm.Task, error) {
+	args := client.Mock.Called(ctx, options)
+	return args.Get(0).([]swarm.Task), args.Error(1)
+}

--- a/release.config.js
+++ b/release.config.js
@@ -1,5 +1,8 @@
 module.exports = {
-  "branches": "main",
+  "branches":  [
+    { "name": "main" },
+    { "name": "beta", "channel": "beta", "prerelease": "beta" },
+  ],
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",


### PR DESCRIPTION
See https://github.com/acouvreur/traefik-ondemand-service/issues/24

Might do the same for Kubernetes and docker classic